### PR TITLE
Fix: apscheduler job miss

### DIFF
--- a/gz-bot/gzctf-bot/plugins/gzctf_bot_qq/main_bot.py
+++ b/gz-bot/gzctf-bot/plugins/gzctf_bot_qq/main_bot.py
@@ -1324,7 +1324,7 @@ async def team_handle(bot, event, args: Message = CommandArg()):
         await bot.send(event, "参数错误!\n使用方法: /team [队伍名]\n或使用 /help 查看帮助")
         return
 
-@H.scheduled_job("interval", seconds=20)
+@H.scheduled_job("interval", seconds=20, misfire_grace_time=None)
 async def _():
     global GAME_LIST, STATUS, GAMENOTICE, GAMECHEATS, BAN_STATUS
     bot = get_bot()


### PR DESCRIPTION
apscheduler 有时会报错 `Run time of job … was missed by …`（可能由于我的机器配置过低），导致定时任务不执行，从而极大影响播报功能。添加 `misfire_grace_time=None` 参数，可以保证定时任务一定会被执行。